### PR TITLE
fix bag errors

### DIFF
--- a/t_bot/record.py
+++ b/t_bot/record.py
@@ -205,8 +205,6 @@ class Record:
         if self.tag:
             self.tag = Tag(old_tag.value + new_tag_list)
             print(f"The new tag {new_tag_list} has been added to old one {old_tag.value}.")
-        else:
-            print(f'The tag has been added yet for this contact. Add first')
 
     def delete_tags(self) -> str:
         '''Deletes all tags.'''

--- a/t_bot/user_funcs.py
+++ b/t_bot/user_funcs.py
@@ -285,7 +285,7 @@ def edit_tag_func(args: list) -> str:
                 print("You entered a wrong number. Please try again.")
                 continue
     else:
-        return f"Please verify your command or the list of tags is empty, please fill it."
+        return f"The list of tags is empty, please fill it."
 
 @input_error
 def delete_tags_func(args: list) -> str:
@@ -378,11 +378,11 @@ def handler(input_string: str) -> list:
     command = ""
     perhaps_command = what_is_command(FUNCTIONS, input_string)
     data = ""
-    input_string = input_string.strip().lower()
+    input_string = input_string.strip().lower() + " "
     for key in FUNCTIONS:
-        if input_string.startswith(key):
+        if input_string.startswith(key + " "):
             command = key
-            data = input_string[len(command):]
+            data = input_string[len(command):].strip()
             break
 
     if not command and \


### PR DESCRIPTION
1. Зміни в хендлері потрібні, щоб не було неадекватної помилки при вводі
add phones, edit tags, add tags і подібним командам, які у нас у однині, а вводяться в множині. А тепер і бонус реагує на невірні команди у множині.
*було б гарно зробити це через regex
  
 2. В цю помилку не має сценарію заходу, вона зайва.
 
```
  else:
        print("The tag has not been added yet for this contact. Add first")
```
3. Додала ще одну вимогу до на писання тегу, щоб виводилася помилка, коли вводиться тільки "#".